### PR TITLE
Remove set contact from i contactable

### DIFF
--- a/contracts/CMTA20.sol
+++ b/contracts/CMTA20.sol
@@ -61,7 +61,20 @@ contract CMTA20 is ERC20, Ownable, Pausable, IContactable, IIdentifiable, IIssua
     contact = _contact;
   }
 
+  /**
+  * Purpose:
+  * This event is emitted when rule engine is changed
+  *
+  * @param newRuleEngine - new rule engine address
+  */
   event LogRuleEngineSet(address indexed newRuleEngine);
+  /**
+  * Purpose:
+  * This event is emitted when the contact information is changed
+  *
+  * @param contact - new contact information
+  */
+  event LogContactSet(string contact);
 
   /**
   * Purpose

--- a/contracts/interface/IContactable.sol
+++ b/contracts/interface/IContactable.sol
@@ -20,7 +20,6 @@ pragma solidity ^0.5.3;
 
 interface IContactable {
   function contact() external view returns (string memory);
-  function setContact(string calldata _contact) external;
 
   /**
   * Purpose:

--- a/contracts/interface/IContactable.sol
+++ b/contracts/interface/IContactable.sol
@@ -20,12 +20,4 @@ pragma solidity ^0.5.3;
 
 interface IContactable {
   function contact() external view returns (string memory);
-
-  /**
-  * Purpose:
-  * This event is emitted when the contact information is changed
-  *
-  * @param contact - new contact information
-  */
-  event LogContactSet(string contact);
 }


### PR DESCRIPTION
This fixes #8. The definition of LogContactSet has been moved from the interface to the contract itself. The event name LogContactSet has not been changed to be in line with all other events name in this contract though.